### PR TITLE
switch to --yaml-roundtrip from yq

### DIFF
--- a/scripts/combine-configs.sh
+++ b/scripts/combine-configs.sh
@@ -18,4 +18,6 @@ if [[ -s "${SHARED_CONFIG_FILE}" ]]; then
 fi
 
 # shellcheck disable=SC2016
-xargs -a "${CONFIG_LIST_MODIFIED}" yq -y -s 'reduce .[] as $item ({}; . * $item)' | tee "${OUTPUT}"
+# NOTE: we use --yaml-roundtrip (-Y) instead of --yaml-output (-y) to preserve YAML tags and styles.
+# We want to keep users' config YAML files as-is
+xargs -a "${CONFIG_LIST_MODIFIED}" yq -Y -s 'reduce .[] as $item ({}; . * $item)' | tee "${OUTPUT}"


### PR DESCRIPTION
This helps to preserve any YAML file's original style.
For example, if the YAML file uses quotes, this will help keep it as-is.

```console
$ cat mock.yml
workflows:
  foo_bar_stg02_60_hoge_release:
    jobs:
      - execute:
          env_no: '02_60'
          region: 'ap-northeast-1'
          filters:
            branches:
              only:
                - main
 
$ python -m yq -y -s 'reduce .[] as $item ({}; . * $item)' mock.yml
workflows:
  foo_bar_stg02_60_hoge_release:
    jobs:
      - execute:
          env_no: 02_60
          region: ap-northeast-1
          filters:
            branches:
              only:
                - main

$ python -m yq -Y -s 'reduce .[] as $item ({}; . * $item)' mock.yml
workflows:
  foo_bar_stg02_60_hoge_release:
    jobs:
      - execute:
          env_no: '02_60'
          region: 'ap-northeast-1'
          filters:
            branches:
              only:
                - main
```

Tested this solution on a sample project here:
https://github.com/kelvintaywl-cci/test-config-splitting

build links here:

| Remark | Build status |
| --- | --- |
| Using Orb @0.0.3 as-is | [Failed](https://app.circleci.com/pipelines/github/kelvintaywl-cci/test-config-splitting/3) |
| Using Orb @0.0.5 as-is | [Failed with same error](https://app.circleci.com/pipelines/github/kelvintaywl-cci/test-config-splitting/6) |
| Importing Orb @0.0.3, and modifying with this change | [Succeed](https://app.circleci.com/pipelines/github/kelvintaywl-cci/test-config-splitting/11) |


**Note**: I imported the config-splitting Orb (@0.0.3) via:

```shell
circleci orb source circle-makotom-orbs/config-splitting@0.0.3
```

This was for debugging a customer's case where they are still using v0.0.3