### PR TITLE
Fix for combining multiple directories selectively

### DIFF
--- a/scripts/select-configs.sh
+++ b/scripts/select-configs.sh
@@ -19,9 +19,8 @@ while read -r module; do
     #   3)  there is no `HEAD~1` (i.e., this is the very first commit for the repo).
     if [[ "${FORCE_ALL}" == 'true' ]] || printenv DIFFS | grep -qs "^${module%%*(/)}"; then
         cat "${module}/${CONFIG_DEPENDENCIES_FILE}" >>"${OUTPUT}"
-        x=$(tail -c 1 ${OUTPUT})
-        if [ "$x" != "" ]
-            then echo >> ${OUTPUT}
+        if [ "$(tail -c 1 "${OUTPUT}")" != "" ]; then
+            echo >>"${OUTPUT}"
         fi
     fi
 done <"${MODULE_LIST_FILE}"

--- a/scripts/select-configs.sh
+++ b/scripts/select-configs.sh
@@ -19,6 +19,10 @@ while read -r module; do
     #   3)  there is no `HEAD~1` (i.e., this is the very first commit for the repo).
     if [[ "${FORCE_ALL}" == 'true' ]] || printenv DIFFS | grep -qs "^${module%%*(/)}"; then
         cat "${module}/${CONFIG_DEPENDENCIES_FILE}" >>"${OUTPUT}"
+        x=$(tail -c 1 ${OUTPUT})
+        if [ "$x" != "" ]
+            then echo >> ${OUTPUT}
+        fi
     fi
 done <"${MODULE_LIST_FILE}"
 


### PR DESCRIPTION
Fixes an issue where directories with a config list that does not have a newline at the end would not combine properly, causing the combine-configs step to fail.
Simply appends a newline to the output file if there isn't one there.

Tested [here](https://app.circleci.com/pipelines/github/JoeMitchellJones/dyn-conf-demo/36/workflows/e300547f-2538-496e-bdda-259dd982bd6c/jobs/47)

Previously, jobs would fail due to configs being combined with no newline, e.g.
`api/api_config.ymlui/ui_config.yml`
instead of
```
api/api_config.yml
ui/ui_config.yml
```
